### PR TITLE
Prepare PTD2Root for Falaise 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Check version meets ou requirements
 # Declare project, which will configure compiler for us
 cmake_minimum_required(VERSION 3.3)
-project(PTD2Root VERSION 0.1.0)
+project(PTD2Root VERSION 1.0.0)
 
 # Will install module and support program
 include(GNUInstallDirs)
@@ -10,11 +10,11 @@ include(GNUInstallDirs)
 # Module uses Falaise, so we need to locate this or fail
 find_package(Falaise REQUIRED)
 
-# Ensure our code can see the Falaise etc headers
-include_directories(${Falaise_INCLUDE_DIRS})
-
 # Build a dynamic library from our sources
 add_library(PTD2Root SHARED ptd2root.h ptd2root.cpp)
+
+# Link it to the FalaiseModule target to pick up dependencies
+target_link_libraries(PTD2Root Falaise::FalaiseModule)
 
 # - Don't link directly as Bayeux/Falaise will export the
 #   needed symbols.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installing
 PTD2Root requires the following software:
 
 - CMake 3.3 or higher
-- Falaise 2.0 or higher
+- Falaise 3.0 or higher
   - Falaise will provide the needed Bayeux and ROOT dependencies
 
 These packages can easily be obtained through the cadfaelbrew package manager.

--- a/p2r.conf
+++ b/p2r.conf
@@ -8,7 +8,7 @@
 # the rest are known system modules. either known to
 # the dpp namespace or
 # the snemo::processing namespace
-[name="flreconstruct.plugins" type=""]
+[name="flreconstruct.plugins" type="flreconstruct::section"]
 plugins : string[1] = "PTD2Root"
 PTD2Root.directory : string = "@CMAKE_INSTALL_FULL_LIBDIR@"
 

--- a/ptd2root.cpp
+++ b/ptd2root.cpp
@@ -50,8 +50,7 @@ void PTD2Root::initialize(const datatools::properties& myConfig,
   }
 
   // Look for services
-  if (flServices.has("geometry"));
-  {
+  if (flServices.has("geometry")) {
     const geomtools::geometry_service& GS = flServices.get<geomtools::geometry_service> ("geometry");
 
     // initialize geometry manager


### PR DESCRIPTION
This addresses the code level issue reported in [homebrew-cadfael Issue 17](https://github.com/SuperNEMO-DBD/homebrew-cadfael/issues/17).

Simply update the CMake scripts for the new `FalaiseModule` target, update the config script for the new scripting interface. Preliminary bump in Version to 1.0.0.